### PR TITLE
Add support for custom tracker comment provided by a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,8 @@ You'll need a seperate resource for each Tracker project.
       - git-repo-path
 ```
 
-The only parameter you need to submit to the resource on a per build basis are the paths to the git repositories which will contain the delivering commits.
+#### Out Parameters
+
+* `repos`: *Required.* Paths to the git repositories which will contain the delivering commits.
+
+* `comment`: *Optional.* A file containing a comment to leave on any delivered stories. If not specified, this comment defaults to "Delivered by Concourse."

--- a/out/models.go
+++ b/out/models.go
@@ -8,7 +8,8 @@ type OutRequest struct {
 }
 
 type Params struct {
-	Repos []string `json:"repos"`
+	Repos       []string `json:"repos"`
+	CommentPath string   `json:"comment"`
 }
 
 type OutResponse struct {


### PR DESCRIPTION
We needed this functionality to link tracker stories to build artifacts for acceptance.
This has been tested against a full concourse deploy.