### PR TITLE
Allow commit messages to support full Tracker syntax

### DIFF
--- a/out/fixtures/stories.json
+++ b/out/fixtures/stories.json
@@ -65,5 +65,125 @@
        "labels":
        [
        ]
+   },
+   {
+       "kind": "story",
+       "id": 223456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "deadline": "2006-01-02T15:04:05Z",
+       "story_type": "release",
+       "name": "Battlestation fully operational",
+       "description": "Everything is proceeding as I have foreseen.",
+       "current_state": "finished",
+       "requested_by_id": 100,
+       "project_id": 99,
+       "url": "http://localhost/story/show/552",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 323456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "deadline": "2006-01-02T15:04:05Z",
+       "story_type": "release",
+       "name": "Battlestation fully operational",
+       "description": "Everything is proceeding as I have foreseen.",
+       "current_state": "finished",
+       "requested_by_id": 100,
+       "project_id": 99,
+       "url": "http://localhost/story/show/552",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 423456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "deadline": "2006-01-02T15:04:05Z",
+       "story_type": "release",
+       "name": "Battlestation fully operational",
+       "description": "Everything is proceeding as I have foreseen.",
+       "current_state": "finished",
+       "requested_by_id": 100,
+       "project_id": 99,
+       "url": "http://localhost/story/show/552",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 223457,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 323457,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 423457,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
    }
 ]

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -125,6 +125,18 @@ var _ = Describe("Out", func() {
 				deliverStoryCommentHandler(trackerToken, projectId, 123456, comment),
 				deliverStoryHandler(trackerToken, projectId, 123457),
 				deliverStoryCommentHandler(trackerToken, projectId, 123457, comment),
+				deliverStoryHandler(trackerToken, projectId, 223456),
+				deliverStoryCommentHandler(trackerToken, projectId, 223456, comment),
+				deliverStoryHandler(trackerToken, projectId, 323456),
+				deliverStoryCommentHandler(trackerToken, projectId, 323456, comment),
+				deliverStoryHandler(trackerToken, projectId, 423456),
+				deliverStoryCommentHandler(trackerToken, projectId, 423456, comment),
+				deliverStoryHandler(trackerToken, projectId, 223457),
+				deliverStoryCommentHandler(trackerToken, projectId, 223457, comment),
+				deliverStoryHandler(trackerToken, projectId, 323457),
+				deliverStoryCommentHandler(trackerToken, projectId, 323457, comment),
+				deliverStoryHandler(trackerToken, projectId, 423457),
+				deliverStoryCommentHandler(trackerToken, projectId, 423457, comment),
 			)
 		})
 
@@ -152,6 +164,30 @@ var _ = Describe("Out", func() {
 			Ω(session.Err).Should(Say("Checking for finished story: .*#123457"))
 			Ω(session.Err).Should(Say("git.*... .*SKIPPING"))
 			Ω(session.Err).Should(Say("middle/git2.*... .*DELIVERING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#223456"))
+			Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#323456"))
+			Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#423456"))
+			Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#223457"))
+			Ω(session.Err).Should(Say("git.*... .*SKIPPING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*DELIVERING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#323457"))
+			Ω(session.Err).Should(Say("git.*... .*SKIPPING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*DELIVERING"))
+
+			Ω(session.Err).Should(Say("Checking for finished story: .*#423457"))
+			Ω(session.Err).Should(Say("git.*... .*SKIPPING"))
+			Ω(session.Err).Should(Say("middle/git2.*... .*DELIVERING"))
 		})
 
 		It("outputs the current time", func() {
@@ -171,6 +207,14 @@ var _ = Describe("Out", func() {
 
 				server.SetHandler(2, deliverStoryCommentHandler(trackerToken, projectId, 123456, "some custom comment"))
 				server.SetHandler(4, deliverStoryCommentHandler(trackerToken, projectId, 123457, "some custom comment"))
+
+				server.SetHandler(6, deliverStoryCommentHandler(trackerToken, projectId, 223456, "some custom comment"))
+				server.SetHandler(8, deliverStoryCommentHandler(trackerToken, projectId, 323456, "some custom comment"))
+				server.SetHandler(10, deliverStoryCommentHandler(trackerToken, projectId, 423456, "some custom comment"))
+
+				server.SetHandler(12, deliverStoryCommentHandler(trackerToken, projectId, 223457, "some custom comment"))
+				server.SetHandler(14, deliverStoryCommentHandler(trackerToken, projectId, 323457, "some custom comment"))
+				server.SetHandler(16, deliverStoryCommentHandler(trackerToken, projectId, 423457, "some custom comment"))
 
 				session := runCommand(outCmd, request)
 				Ω(session.Err).Should(Say("Checking for finished story: .*#123456"))

--- a/out/scripts/setup.sh
+++ b/out/scripts/setup.sh
@@ -33,6 +33,9 @@ pushd $DIR/git
 	touch file.txt
 	git add file.txt
 	git commit -m "add file [Finishes #123456]"
+	git commit -m "add file [#223456 Finishes]" --allow-empty
+	git commit -m "add file [Finished #323456]" --allow-empty
+	git commit -m "add file [Finish #423456]" --allow-empty
 popd
 
 # git2: git harder directory
@@ -48,6 +51,9 @@ pushd $DIR/middle/git2
 	git commit -m "fix bug
 
 	[fixes #123457]"
+	git commit -m "fix bug [#223457 fixes]" --allow-empty
+	git commit -m "fix bug [fixed #323457]" --allow-empty
+	git commit -m "fix bug [fix #423457]" --allow-empty
 popd
 
 if [ ! -z ${ACTUAL_STORY_ID} ]; then


### PR DESCRIPTION
Previously, only [finishes #id] or [fixes #id] were supported, but
tracker supports "finish", "finished", "fix", "fixed", as well as
putting the verb after the #id.

Signed-off-by: Frank Kotsianas <fkotsianas@pivotal.io>