### PR TITLE
Completed Story Tags

### DIFF
--- a/out/cmd/out/main.go
+++ b/out/cmd/out/main.go
@@ -87,10 +87,11 @@ func deliverIfDone(client tracker.ProjectClient, story tracker.Story, sources, c
 
 		sayf(colorstring.Color("  [white][bold]%s[default]...%s"), repo, strings.Repeat(" ", 80-2-3-10-len(repo)))
 
+		outputCompletes := checkGitLog([]string{"completes", "completed", "complete"}, story, dir)
 		outputFixes := checkGitLog([]string{"fixes", "fixed", "fix"}, story, dir)
 		outputFinishes := checkGitLog([]string{"finishes", "finished", "finish"}, story, dir)
 
-		if len(outputFixes) > 0 || len(outputFinishes) > 0 {
+		if len(outputCompletes) > 0 || len(outputFixes) > 0 || len(outputFinishes) > 0 {
 			sayf(colorstring.Color("[green]DELIVERING\n"))
 			if comment == "" {
 				client.DeliverStory(story.ID)

--- a/out/fixtures/stories.json
+++ b/out/fixtures/stories.json
@@ -128,6 +128,66 @@
    },
    {
        "kind": "story",
+       "id": 523456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 623456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
+       "id": 723456,
+       "created_at": "2006-01-02T15:04:05Z",
+       "updated_at": "2006-01-02T15:04:05Z",
+       "estimate": 2,
+       "story_type": "feature",
+       "name": "Bring me the passengers",
+       "description": "ignore the droids",
+       "current_state": "finished",
+       "requested_by_id": 101,
+       "project_id": 99,
+       "url": "http://localhost/story/show/555",
+       "owner_ids":
+       [
+       ],
+       "labels":
+       [
+       ]
+   },
+   {
+       "kind": "story",
        "id": 223457,
        "created_at": "2006-01-02T15:04:05Z",
        "updated_at": "2006-01-02T15:04:05Z",

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -132,6 +132,9 @@ var _ = Describe("Out", func() {
 					deliverStoryHandler(trackerToken, projectId, 223456),
 					deliverStoryHandler(trackerToken, projectId, 323456),
 					deliverStoryHandler(trackerToken, projectId, 423456),
+					deliverStoryHandler(trackerToken, projectId, 523456),
+					deliverStoryHandler(trackerToken, projectId, 623456),
+					deliverStoryHandler(trackerToken, projectId, 723456),
 					deliverStoryHandler(trackerToken, projectId, 223457),
 					deliverStoryHandler(trackerToken, projectId, 323457),
 					deliverStoryHandler(trackerToken, projectId, 423457),
@@ -168,6 +171,18 @@ var _ = Describe("Out", func() {
 				Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
 
 				Ω(session.Err).Should(Say("Checking for finished story: .*#423456"))
+				Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+				Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+				Ω(session.Err).Should(Say("Checking for finished story: .*#523456"))
+				Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+				Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+				Ω(session.Err).Should(Say("Checking for finished story: .*#623456"))
+				Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
+				Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
+
+				Ω(session.Err).Should(Say("Checking for finished story: .*#723456"))
 				Ω(session.Err).Should(Say("git.*... .*DELIVERING"))
 				Ω(session.Err).Should(Say("middle/git2.*... .*SKIPPING"))
 
@@ -212,6 +227,12 @@ var _ = Describe("Out", func() {
 					deliverStoryCommentHandler(trackerToken, projectId, 323456, "some custom comment"),
 					deliverStoryHandler(trackerToken, projectId, 423456),
 					deliverStoryCommentHandler(trackerToken, projectId, 423456, "some custom comment"),
+					deliverStoryHandler(trackerToken, projectId, 523456),
+					deliverStoryCommentHandler(trackerToken, projectId, 523456, "some custom comment"),
+					deliverStoryHandler(trackerToken, projectId, 623456),
+					deliverStoryCommentHandler(trackerToken, projectId, 623456, "some custom comment"),
+					deliverStoryHandler(trackerToken, projectId, 723456),
+					deliverStoryCommentHandler(trackerToken, projectId, 723456, "some custom comment"),
 					deliverStoryHandler(trackerToken, projectId, 223457),
 					deliverStoryCommentHandler(trackerToken, projectId, 223457, "some custom comment"),
 					deliverStoryHandler(trackerToken, projectId, 323457),

--- a/out/scripts/setup.sh
+++ b/out/scripts/setup.sh
@@ -36,6 +36,9 @@ pushd $DIR/git
 	git commit -m "add file [#223456 Finishes]" --allow-empty
 	git commit -m "add file [Finished #323456]" --allow-empty
 	git commit -m "add file [Finish #423456]" --allow-empty
+	git commit -m "add file [Completes #523456]" --allow-empty
+	git commit -m "add file [Completed #623456]" --allow-empty
+	git commit -m "add file [Complete #723456]" --allow-empty
 popd
 
 # git2: git harder directory


### PR DESCRIPTION
Previously, this resource searched story tags for `fixed` and `finished` verbs and their variations. This was an incomplete list of Tracker-supported verbs as [variations on `completed`](https://www.pivotaltracker.com/help/api?version=v5#Tracker_Updates_in_SCM_Post_Commit_Hooks) are acceptable as well.  This change updates the implementation to search for `completed` and its variations as well.