### PR TITLE
Enable testing against parameterized projects

### DIFF
--- a/out/out_test.go
+++ b/out/out_test.go
@@ -48,12 +48,16 @@ var _ = Describe("Out", func() {
 		var (
 			request            out.OutRequest
 			storyId            string
+			projectId          string
 			actualTrackerToken string
 		)
 
-		projectId := "1412996"
-
 		BeforeEach(func() {
+			projectId = os.Getenv("TRACKER_PROJECT")
+			if projectId == "" {
+				Skip("TRACKER_PROJECT must be provided.")
+			}
+
 			actualTrackerToken = os.Getenv("TRACKER_TOKEN")
 			if actualTrackerToken == "" {
 				Skip("TRACKER_TOKEN must be provided.")


### PR DESCRIPTION
ALERT: you will probably need to change the configuration of env variables for your pipeline deployed http://ci.concourse.ci/pipelines/resources/jobs/tracker-resource

But this unblocks people who are not on the concourse team; otherwise we have to change the hard-coded project ID to run the Ginkgo tests