### PR TITLE
Extend parameterization of Tracker_Project into task.yml

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -11,6 +11,7 @@ outputs:
 
 params:
   TRACKER_TOKEN:
+  TRACKER_PROJECT:
 
 run:
   path: gopath/src/github.com/concourse/tracker-resource/scripts/ci


### PR DESCRIPTION
We're actually getting a new skipped test here: http://ci.concourse.ci/pipelines/resources/jobs/tracker-resource/builds/42

I think you need this params field, and need to add it to your deployments (though I can't see your deployments situation)