### PR TITLE
Comment on delivered stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ You'll need a separate resource for each Tracker project.
 * `repos`: *Required.* Paths to the git repositories which will contain the delivering commits.
 
 * `comment`: *Optional.* A file containing a comment to leave on any delivered stories.
+
+* `delivered`: *Optional.* An option specifying whether to leave a comment on pre-delivered stories. Defaults to 'false'.

--- a/out/models.go
+++ b/out/models.go
@@ -10,6 +10,7 @@ type OutRequest struct {
 type Params struct {
 	Repos       []string `json:"repos"`
 	CommentPath string   `json:"comment"`
+	Delivered   bool     `json:"delivered"`
 }
 
 type OutResponse struct {

--- a/out/scripts/setup.sh
+++ b/out/scripts/setup.sh
@@ -4,6 +4,7 @@ set -e
 
 DIR=$1
 ACTUAL_STORY_ID=$2
+ACTUAL_DELIVERED_STORY_ID=$3
 
 # random file
 pushd $DIR
@@ -62,20 +63,38 @@ pushd $DIR/middle/git2
 	git commit -m "fix previously rejected story badly so it gets rejected again [Complete #666666]" --allow-empty
 popd
 
-if [ ! -z ${ACTUAL_STORY_ID} ]; then
-	echo "ACTUAL_STORY_ID: ${ACTUAL_STORY_ID}"
-	# git3: git with a vengence directory
+if [ ! -z ${ACTUAL_STORY_ID} ] || [ ! -z ${ACTUAL_DELIVERED_STORY_ID} ] ; then
 	mkdir -p $DIR/middle/git3
 	pushd $DIR/middle/git3
 		git init
 
 		git config user.email "concourse@example.com"
 		git config user.name "Concourse Tracker Resource"
+	popd
+fi
 
+if [ ! -z ${ACTUAL_STORY_ID} ]; then
+	echo "ACTUAL_STORY_ID: ${ACTUAL_STORY_ID}"
+	# git3: git with a vengence directory
+	mkdir -p $DIR/middle/git3
+	pushd $DIR/middle/git3
 		echo "bugfix" > file.txt
 		git add file.txt
 		git commit -m "fix bug
 
 		[fixes #${ACTUAL_STORY_ID}]"
+	popd
+fi
+
+if [ ! -z ${ACTUAL_DELIVERED_STORY_ID} ]; then
+	echo "ACTUAL_DELIVERED_STORY_ID: ${ACTUAL_DELIVERED_STORY_ID}"
+	# git3: git with a vengence directory
+	mkdir -p $DIR/middle/git3
+	pushd $DIR/middle/git3
+		echo "feature" > file.txt
+		git add file.txt
+		git commit -m "add feature
+
+		[finishes #${ACTUAL_DELIVERED_STORY_ID}]"
 	popd
 fi


### PR DESCRIPTION
We have a pipeline where two jobs use the tracker resource to deliver and comment on stories. If they both need to comment on a story, only the first one to run will comment. The other will see that the story is delivered and not comment on it.

This lets users optionally allow the resource to comment on stories that are already delivered.

Signed-off-by: Mark DeLillo mdelillo@pivotal.io
